### PR TITLE
Add outbound SOCKS5 proxy support for upstream connections

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -39,6 +40,7 @@ func parseFlags(args []string) (*Config, error) {
 	dcIPDefault := fs.String("dc-ip-default", "149.154.167.220", "Default WS target IP for all implicit DCs when --dc-ip is not provided")
 	dcIPDefaultPool := fs.String("dc-ip-default-pool", "", "Default WS target IP pool for implicit DCs, comma-separated")
 	pprofListen := fs.String("pprof-listen", "", "Optional pprof listen address (e.g. 127.0.0.1:6060)")
+	outboundProxy := fs.String("outbound-proxy", "", "SOCKS5 proxy URL for upstream connections (socks5://host:port); falls back to TG_OUTBOUND_PROXY env var if unset")
 
 	var dcIPs multiFlag
 	var dcIPPools multiFlag
@@ -170,6 +172,15 @@ func parseFlags(args []string) (*Config, error) {
 		workerDomains = wd
 	}
 
+	outboundProxyURL := strings.TrimSpace(*outboundProxy)
+	if outboundProxyURL == "" {
+		outboundProxyURL = strings.TrimSpace(os.Getenv("TG_OUTBOUND_PROXY"))
+	}
+	outboundDialer, err := buildOutboundDialer(outboundProxyURL)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := &Config{
 		Host:                         *host,
 		Port:                         *port,
@@ -197,6 +208,8 @@ func parseFlags(args []string) (*Config, error) {
 		LogMaxMB:                     *logMaxMB,
 		LogBackups:                   maxInt(*logBackups, 0),
 		PprofListen:                  strings.TrimSpace(*pprofListen),
+		OutboundProxy:                outboundProxyURL,
+		outboundDialer:               outboundDialer,
 	}
 
 	cfg.setCFProxyDomains(domainPool)

--- a/src/go.mod
+++ b/src/go.mod
@@ -3,3 +3,5 @@ module tg-ws-proxy
 go 1.23.12
 
 require github.com/gorilla/websocket v1.5.3
+
+require golang.org/x/net v0.33.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,2 +1,4 @@
+github.com/golang/net v0.33.0 h1:FzcpcbOtyS4vg5RCH9L/+ytgsZB06dh2ePK25I/ljnE=
+github.com/golang/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/src/outbound_proxy.go
+++ b/src/outbound_proxy.go
@@ -1,0 +1,83 @@
+package main
+
+// outbound_proxy.go — исходящий SOCKS5-прокси для upstream-соединений
+// (к датацентрам Telegram / Cloudflare-фоллбэку).
+//
+// Мотивация: позволяет направить исходящий трафик tg-ws-proxy через
+// уже поднятый локальный SOCKS5-эндпоинт (например, Opera Proxy в
+// -socks-mode на роутере) — то есть переиспользовать существующую
+// прокси-инфраструктуру вместо того, чтобы городить отдельный
+// tun2socks-мост. Названо TG_OUTBOUND_PROXY по аналогии с одноимённой
+// переменной в tg-ws-proxy-rs (valnesfjord) — для единообразия среди
+// разных реализаций одного и того же протокола, чтобы конфиг можно
+// было переносить между ними без переучивания.
+//
+// Единая точка входа — dialUpstream(). Все места, которые раньше
+// делали newUpstreamDialer(timeout).Dial(...)/.DialContext(...)
+// напрямую, теперь идут через неё.
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+// buildOutboundDialer парсит cfg.OutboundProxy (пусто = без прокси) и
+// возвращает proxy.ContextDialer. Вызывается один раз при старте (см.
+// Config.outboundDialer, кэшируется — SOCKS5-дайлер из x/net/proxy не
+// хранит состояния соединения, безопасно переиспользовать конкурентно
+// между горутинами).
+func buildOutboundDialer(rawURL string) (proxy.ContextDialer, error) {
+	if rawURL == "" {
+		return nil, nil
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --outbound-proxy URL: %w", err)
+	}
+	switch u.Scheme {
+	case "socks5", "socks5h":
+		// Собственно ничего не отличаем между socks5/socks5h — резолв
+		// доменов у нас никогда и не нужен на этом этапе: dialUpstream
+		// всегда получает уже разрешённый IP (targetIP), а не домен.
+	default:
+		return nil, fmt.Errorf(
+			"unsupported --outbound-proxy scheme %q (only socks5:// is supported)",
+			u.Scheme)
+	}
+
+	d, err := proxy.FromURL(u, proxy.Direct)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build outbound proxy dialer: %w", err)
+	}
+
+	cd, ok := d.(proxy.ContextDialer)
+	if !ok {
+		// В x/net/proxy все встроенные дайлеры (включая SOCKS5)
+		// реализуют ContextDialer, так что это защита от неожиданного
+		// изменения в будущей версии зависимости, а не ожидаемый путь.
+		return nil, fmt.Errorf(
+			"outbound proxy dialer for scheme %q does not support context dialing",
+			u.Scheme)
+	}
+	return cd, nil
+}
+
+// dialUpstream — единая точка выхода наружу (к DC Telegram или
+// Cloudflare-фоллбэку). Если cfg.outboundDialer == nil — обычный прямой
+// TCP-дайл (текущее поведение по умолчанию, без изменений). Если
+// задан — весь трафик идёт через него.
+func dialUpstream(ctx context.Context, cfg *Config, network, addr string, timeout time.Duration) (net.Conn, error) {
+	if cfg == nil || cfg.outboundDialer == nil {
+		dctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		return newUpstreamDialer(timeout).DialContext(dctx, network, addr)
+	}
+	dctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return cfg.outboundDialer.DialContext(dctx, network, addr)
+}

--- a/src/outbound_proxy_test.go
+++ b/src/outbound_proxy_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBuildOutboundDialerEmpty(t *testing.T) {
+	d, err := buildOutboundDialer("")
+	if err != nil {
+		t.Fatalf("unexpected error for empty proxy URL: %v", err)
+	}
+	if d != nil {
+		t.Fatalf("expected nil dialer for empty proxy URL, got %v", d)
+	}
+}
+
+func TestBuildOutboundDialerInvalidScheme(t *testing.T) {
+	_, err := buildOutboundDialer("http://127.0.0.1:8080")
+	if err == nil {
+		t.Fatal("expected error for unsupported scheme (only socks5:// is supported), got nil")
+	}
+}
+
+func TestBuildOutboundDialerInvalidURL(t *testing.T) {
+	_, err := buildOutboundDialer("://not a url")
+	if err == nil {
+		t.Fatal("expected error for malformed URL, got nil")
+	}
+}
+
+// minimalSOCKS5Server — достаточный для теста RFC1928-сервер: без
+// аутентификации, только CONNECT. Нужен, чтобы доказать, что
+// dialUpstream() реально устанавливает TCP-соединение ЧЕРЕЗ SOCKS5, а
+// не просто не падает с ошибкой при наличии cfg.OutboundProxy.
+func minimalSOCKS5Server(t *testing.T, echoAddr string) (addr string, connectedThrough *int32) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test SOCKS5 listener: %v", err)
+	}
+	var count int32
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				r := bufio.NewReader(c)
+
+				// greeting: VER NMETHODS METHODS...
+				ver, _ := r.ReadByte()
+				if ver != 0x05 {
+					return
+				}
+				nmethods, _ := r.ReadByte()
+				_, _ = io.CopyN(io.Discard, r, int64(nmethods))
+				// no-auth reply
+				_, _ = c.Write([]byte{0x05, 0x00})
+
+				// request: VER CMD RSV ATYP ADDR PORT
+				header := make([]byte, 4)
+				if _, err := io.ReadFull(r, header); err != nil {
+					return
+				}
+				if header[1] != 0x01 { // только CONNECT
+					_, _ = c.Write([]byte{0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+					return
+				}
+				switch header[3] {
+				case 0x01: // IPv4
+					_, _ = io.CopyN(io.Discard, r, 4)
+				case 0x03: // domain
+					l, _ := r.ReadByte()
+					_, _ = io.CopyN(io.Discard, r, int64(l))
+				case 0x04: // IPv6
+					_, _ = io.CopyN(io.Discard, r, 16)
+				}
+				var port uint16
+				_ = binary.Read(r, binary.BigEndian, &port)
+
+				// Успех — подключаемся к реальному echo-адресу (тестовому
+				// upstream-серверу), игнорируя запрошенный адрес: для
+				// теста важно доказать сам факт прохождения через SOCKS5,
+				// а не полную адресацию.
+				upstream, err := net.Dial("tcp", echoAddr)
+				if err != nil {
+					_, _ = c.Write([]byte{0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+					return
+				}
+				defer upstream.Close()
+
+				_, _ = c.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+				atomic.AddInt32(&count, 1)
+
+				done := make(chan struct{}, 2)
+				go func() { _, _ = io.Copy(upstream, r); done <- struct{}{} }()
+				go func() { _, _ = io.Copy(c, upstream); done <- struct{}{} }()
+				<-done
+			}(conn)
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln.Addr().String(), &count
+}
+
+func TestDialUpstreamThroughSOCKS5(t *testing.T) {
+	// echo-сервер — "настоящий" upstream, к которому в реальности пойдёт
+	// запрос tg-ws-proxy (в тесте — просто эхо байт для проверки, что
+	// данные реально прошли по цепочке client -> SOCKS5 -> upstream).
+	echoLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start echo listener: %v", err)
+	}
+	defer echoLn.Close()
+	go func() {
+		for {
+			c, err := echoLn.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 5)
+				if _, err := io.ReadFull(c, buf); err != nil {
+					return
+				}
+				_, _ = c.Write(buf)
+			}(c)
+		}
+	}()
+
+	socksAddr, hits := minimalSOCKS5Server(t, echoLn.Addr().String())
+
+	cfg := &Config{OutboundProxy: "socks5://" + socksAddr}
+	dialer, err := buildOutboundDialer(cfg.OutboundProxy)
+	if err != nil {
+		t.Fatalf("buildOutboundDialer failed: %v", err)
+	}
+	cfg.outboundDialer = dialer
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := dialUpstream(ctx, cfg, "tcp", "203.0.113.1:443", 5*time.Second)
+	if err != nil {
+		t.Fatalf("dialUpstream via SOCKS5 failed: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("hello")); err != nil {
+		t.Fatalf("write through proxy failed: %v", err)
+	}
+	resp := make([]byte, 5)
+	if _, err := io.ReadFull(conn, resp); err != nil {
+		t.Fatalf("read through proxy failed: %v", err)
+	}
+	if string(resp) != "hello" {
+		t.Fatalf("echo mismatch: got %q", resp)
+	}
+	if atomic.LoadInt32(hits) < 1 {
+		t.Fatal("expected at least one connection to pass through the SOCKS5 server, but none did " +
+			"— dialUpstream is not actually routing through the configured proxy")
+	}
+}
+
+func TestDialUpstreamWithoutProxyIsDirect(t *testing.T) {
+	// cfg == nil (или OutboundProxy не задан) — dialUpstream должен
+	// вести себя как раньше (прямой TCP), не ломая обратную
+	// совместимость для всех, кто не настраивал --outbound-proxy.
+	echoLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start echo listener: %v", err)
+	}
+	defer echoLn.Close()
+	go func() {
+		c, err := echoLn.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		buf := make([]byte, 2)
+		_, _ = io.ReadFull(c, buf)
+		_, _ = c.Write(buf)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	conn, err := dialUpstream(ctx, nil, "tcp", echoLn.Addr().String(), 3*time.Second)
+	if err != nil {
+		t.Fatalf("direct dialUpstream (no cfg) failed: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte("hi")); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+}

--- a/src/pool.go
+++ b/src/pool.go
@@ -92,7 +92,7 @@ func (p *wsPool) refill(cfg *Config, key wsPoolKey, domains []string) {
 		if frontingActive() {
 			connect = poolWSConnectFronting
 		}
-		conn, _, err := connect(key.TargetIP, domains, poolConnectTimeout)
+		conn, _, err := connect(cfg, key.TargetIP, domains, poolConnectTimeout)
 		if err != nil {
 			return
 		}

--- a/src/pool_test.go
+++ b/src/pool_test.go
@@ -80,7 +80,7 @@ func TestPoolRefillKeepsSizeLimit(t *testing.T) {
 	var cleanupsMu sync.Mutex
 	var cleanups []func()
 	var calls int64
-	poolWSConnect = func(string, []string, time.Duration) (*websocket.Conn, *http.Response, error) {
+	poolWSConnect = func(_ *Config, _ string, _ []string, _ time.Duration) (*websocket.Conn, *http.Response, error) {
 		atomic.AddInt64(&calls, 1)
 		conn, _, err := websocket.DefaultDialer.Dial(url, nil)
 		if err != nil {
@@ -131,7 +131,7 @@ func TestPoolRefillDialsSequentially(t *testing.T) {
 	var cleanups []func()
 	var active int64
 	var maxActive int64
-	poolWSConnect = func(string, []string, time.Duration) (*websocket.Conn, *http.Response, error) {
+	poolWSConnect = func(_ *Config, _ string, _ []string, _ time.Duration) (*websocket.Conn, *http.Response, error) {
 		cur := atomic.AddInt64(&active, 1)
 		for {
 			max := atomic.LoadInt64(&maxActive)

--- a/src/server.go
+++ b/src/server.go
@@ -239,7 +239,7 @@ func handleMTProtoClient(client net.Conn, cfg *Config, hi *handshakeInfo, secret
 				return false
 			}
 			log.Printf("INFO   [%s] DC%d%s -> TCP fallback to %s:443", label, hi.DC, mediaTag, fallback)
-			err := tcpFallback(client, fallback, relayInit, cltDec, cltEnc, tgEnc, tgDec)
+			err := tcpFallback(cfg, client, fallback, relayInit, cltDec, cltEnc, tgEnc, tgDec)
 			if err == nil {
 				log.Printf("INFO   [%s] DC%d%s TCP fallback closed", label, hi.DC, mediaTag)
 				return true
@@ -309,7 +309,7 @@ func handleMTProtoClient(client net.Conn, cfg *Config, hi *handshakeInfo, secret
 		for _, target := range directTargets {
 			for _, d := range domains {
 				debugf(cfg, "[%s] DC%d%s -> wss://%s/apiws via %s", label, hi.DC, mediaTag, d, target)
-				conn, resp, err := dialWS(target, d, timeout)
+				conn, resp, err := dialWS(cfg, target, d, timeout)
 				if err == nil {
 					allRedirect = false
 					return conn, target, wsFailedRedirect, allRedirect, timedOut
@@ -339,7 +339,7 @@ func handleMTProtoClient(client net.Conn, cfg *Config, hi *handshakeInfo, secret
 	connectFronting := func(reason string) (*websocket.Conn, string) {
 		for _, target := range directTargets {
 			log.Printf("INFO   [%s] DC%d%s -> fronting %s via %s", label, hi.DC, mediaTag, reason, target)
-			conn, _, err := wsConnectFronting(target, domains, wsConnectTimeout)
+			conn, _, err := wsConnectFronting(cfg, target, domains, wsConnectTimeout)
 			if err == nil {
 				setFrontingActive()
 				atomic.AddInt64(&stats.connectionsFront, 1)

--- a/src/transport.go
+++ b/src/transport.go
@@ -23,15 +23,15 @@ var ioBufPool = sync.Pool{
 	},
 }
 
-func dialWS(targetIP, domain string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
-	return dialWSWithSNI(targetIP, domain, domain, timeout)
+func dialWS(cfg *Config, targetIP, domain string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
+	return dialWSWithSNI(cfg, targetIP, domain, domain, timeout)
 }
 
-func dialWSFronting(targetIP, domain string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
-	return dialWSWithSNI(targetIP, domain, "sprinthost.ru", timeout)
+func dialWSFronting(cfg *Config, targetIP, domain string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
+	return dialWSWithSNI(cfg, targetIP, domain, "sprinthost.ru", timeout)
 }
 
-func dialWSWithSNI(targetIP, domain, sni string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
+func dialWSWithSNI(cfg *Config, targetIP, domain, sni string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
 	u := url.URL{Scheme: "wss", Host: domain, Path: "/apiws"}
 	dialer := websocket.Dialer{
 		HandshakeTimeout: timeout,
@@ -41,7 +41,7 @@ func dialWSWithSNI(targetIP, domain, sni string, timeout time.Duration) (*websoc
 			InsecureSkipVerify: true,
 		},
 		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return newUpstreamDialer(timeout).DialContext(ctx, "tcp", net.JoinHostPort(targetIP, "443"))
+			return dialUpstream(ctx, cfg, "tcp", net.JoinHostPort(targetIP, "443"), timeout)
 		},
 	}
 	headers := http.Header{}
@@ -236,8 +236,8 @@ func bridgeWS(label string, cfg *Config, dc int, isMedia bool, client net.Conn, 
 	)
 }
 
-func tcpFallback(client net.Conn, dst string, relayInit []byte, cltDec, cltEnc, tgEnc, tgDec cipher.Stream) error {
-	r, err := newUpstreamDialer(tcpDialTimeout).Dial("tcp", net.JoinHostPort(dst, "443"))
+func tcpFallback(cfg *Config, client net.Conn, dst string, relayInit []byte, cltDec, cltEnc, tgEnc, tgDec cipher.Stream) error {
+	r, err := dialUpstream(context.Background(), cfg, "tcp", net.JoinHostPort(dst, "443"), tcpDialTimeout)
 	if err != nil {
 		warnf("TCP fallback to %s:443 failed: %v", dst, err)
 		return err
@@ -332,19 +332,19 @@ func tcpFallback(client net.Conn, dst string, relayInit []byte, cltDec, cltEnc, 
 	return nil
 }
 
-func wsConnect(targetIP string, domains []string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
-	return wsConnectWithDialer(targetIP, domains, timeout, dialWS)
+func wsConnect(cfg *Config, targetIP string, domains []string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
+	return wsConnectWithDialer(cfg, targetIP, domains, timeout, dialWS)
 }
 
-func wsConnectFronting(targetIP string, domains []string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
-	return wsConnectWithDialer(targetIP, domains, timeout, dialWSFronting)
+func wsConnectFronting(cfg *Config, targetIP string, domains []string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
+	return wsConnectWithDialer(cfg, targetIP, domains, timeout, dialWSFronting)
 }
 
-func wsConnectWithDialer(targetIP string, domains []string, timeout time.Duration, dial func(string, string, time.Duration) (*websocket.Conn, *http.Response, error)) (*websocket.Conn, *http.Response, error) {
+func wsConnectWithDialer(cfg *Config, targetIP string, domains []string, timeout time.Duration, dial func(*Config, string, string, time.Duration) (*websocket.Conn, *http.Response, error)) (*websocket.Conn, *http.Response, error) {
 	var lastErr error
 	var lastResp *http.Response
 	for _, domain := range domains {
-		conn, resp, err := dial(targetIP, domain, timeout)
+		conn, resp, err := dial(cfg, targetIP, domain, timeout)
 		if err == nil {
 			return conn, resp, nil
 		}
@@ -357,7 +357,7 @@ func wsConnectWithDialer(targetIP string, domains []string, timeout time.Duratio
 	return nil, lastResp, lastErr
 }
 
-func dialWSByDomain(domain string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
+func dialWSByDomain(cfg *Config, domain string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
 	u := url.URL{Scheme: "wss", Host: domain, Path: "/apiws"}
 	dialer := websocket.Dialer{
 		HandshakeTimeout: timeout,
@@ -367,7 +367,7 @@ func dialWSByDomain(domain string, timeout time.Duration) (*websocket.Conn, *htt
 			InsecureSkipVerify: true,
 		},
 		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return newUpstreamDialer(timeout).DialContext(ctx, network, addr)
+			return dialUpstream(ctx, cfg, network, addr, timeout)
 		},
 	}
 	headers := http.Header{}
@@ -376,7 +376,7 @@ func dialWSByDomain(domain string, timeout time.Duration) (*websocket.Conn, *htt
 	return dialer.Dial(u.String(), headers)
 }
 
-func dialWSWorker(worker, dst string, dc int, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
+func dialWSWorker(cfg *Config, worker, dst string, dc int, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
 	q := url.Values{}
 	q.Set("dst", dst)
 	q.Set("dc", strconv.Itoa(dc))
@@ -389,7 +389,7 @@ func dialWSWorker(worker, dst string, dc int, timeout time.Duration) (*websocket
 			InsecureSkipVerify: true,
 		},
 		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return newUpstreamDialer(timeout).DialContext(ctx, network, addr)
+			return dialUpstream(ctx, cfg, network, addr, timeout)
 		},
 	}
 	headers := http.Header{}
@@ -409,7 +409,7 @@ func cfWorkerFallback(label string, cfg *Config, dc int, isMedia bool, dst strin
 
 	for _, worker := range cfg.cfproxyWorkerDomainsForTry() {
 		logf("INFO   [%s] DC%d%s -> CF worker wss://%s/apiws?dst=%s", label, dc, mediaTag, worker, dst)
-		ws, _, err := dialWSWorker(worker, dst, dc, wsConnectTimeout)
+		ws, _, err := dialWSWorker(cfg, worker, dst, dc, wsConnectTimeout)
 		if err != nil {
 			atomic.AddInt64(&stats.wsErrors, 1)
 			warnf("[%s] DC%d%s CF worker %s failed: %v", label, dc, mediaTag, worker, err)
@@ -439,7 +439,7 @@ func cfproxyFallback(label string, cfg *Config, dc int, isMedia bool, client net
 	for _, baseDomain := range cfg.cfproxyDomainsForTry(dc) {
 		domain := fmt.Sprintf("kws%d.%s", dc, baseDomain)
 		debugf(cfg, "[%s] DC%d%s -> CF proxy wss://%s/apiws", label, dc, mediaTag, domain)
-		ws, resp, err := dialWSByDomain(domain, wsConnectTimeout)
+		ws, resp, err := dialWSByDomain(cfg, domain, wsConnectTimeout)
 		if err != nil {
 			atomic.AddInt64(&stats.wsErrors, 1)
 			firstFailure := cfg.markCFProxyDomainFailed(baseDomain, cfproxyFailureCooldown(err))

--- a/src/types.go
+++ b/src/types.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"golang.org/x/net/proxy"
 )
 
 type Config struct {
@@ -34,6 +36,8 @@ type Config struct {
 	LogMaxMB                     float64
 	LogBackups                   int
 	PprofListen                  string
+	OutboundProxy                string
+	outboundDialer               proxy.ContextDialer
 	cfproxyMu                    sync.RWMutex
 	cfproxyFailUntil             map[string]time.Time
 }


### PR DESCRIPTION
Routes all WS/TCP dials to Telegram DCs and CF fallback (worker, cfproxy) through a SOCKS5 proxy when configured, instead of always dialing the WAN directly.

Motivation: lets tg-ws-proxy reuse an already-running local SOCKS5 proxy (e.g. a VPN client's SOCKS5 mode) as its outbound path, without requiring a separate TUN-based bridge.

- New --outbound-proxy flag / TG_OUTBOUND_PROXY env var (socks5://[user:pass@]host:port). Named to match the equivalent option in valnesfjord/tg-ws-proxy-rs for cross-compatible configs.
- Empty by default -- fully backward compatible, no behavior change when unset.
- Single choke point (dialUpstream in outbound_proxy.go); threaded through all 5 real dial call sites (dialWS/dialWSFronting family, dialWSByDomain, dialWSWorker, tcpFallback, pool refill).
- Fake-TLS masking-domain decoy traffic (proxyToMaskingDomain) intentionally left as direct dial -- it's not Telegram traffic, no need to route it through the proxy.
- New tests in outbound_proxy_test.go, including an end-to-end test against a minimal in-process SOCKS5 server (not just a doesn't-crash check).

NOTE: go.sum needs 'go mod tidy' run in an environment with normal network access before merging -- I built/tested this from a sandboxed environment without access to sum.golang.org, so the golang.org/x/net checksum entries here may not be correct.