### PR TITLE
security: verify upstream TLS certificates

### DIFF
--- a/src/transport.go
+++ b/src/transport.go
@@ -23,6 +23,13 @@ var ioBufPool = sync.Pool{
 	},
 }
 
+func newUpstreamTLSConfig(serverName string) *tls.Config {
+	return &tls.Config{
+		ServerName: serverName,
+		MinVersion: tls.VersionTLS12,
+	}
+}
+
 func dialWS(targetIP, domain string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
 	return dialWSWithSNI(targetIP, domain, domain, timeout)
 }
@@ -36,10 +43,7 @@ func dialWSWithSNI(targetIP, domain, sni string, timeout time.Duration) (*websoc
 	dialer := websocket.Dialer{
 		HandshakeTimeout: timeout,
 		Subprotocols:     []string{"binary"},
-		TLSClientConfig: &tls.Config{
-			ServerName:         sni,
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig:  newUpstreamTLSConfig(sni),
 		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return newUpstreamDialer(timeout).DialContext(ctx, "tcp", net.JoinHostPort(targetIP, "443"))
 		},
@@ -362,10 +366,7 @@ func dialWSByDomain(domain string, timeout time.Duration) (*websocket.Conn, *htt
 	dialer := websocket.Dialer{
 		HandshakeTimeout: timeout,
 		Subprotocols:     []string{"binary"},
-		TLSClientConfig: &tls.Config{
-			ServerName:         domain,
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig:  newUpstreamTLSConfig(domain),
 		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return newUpstreamDialer(timeout).DialContext(ctx, network, addr)
 		},
@@ -384,10 +385,7 @@ func dialWSWorker(worker, dst string, dc int, timeout time.Duration) (*websocket
 	dialer := websocket.Dialer{
 		HandshakeTimeout: timeout,
 		Subprotocols:     []string{"binary"},
-		TLSClientConfig: &tls.Config{
-			ServerName:         worker,
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig:  newUpstreamTLSConfig(worker),
 		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return newUpstreamDialer(timeout).DialContext(ctx, network, addr)
 		},

--- a/src/transport_tls_test.go
+++ b/src/transport_tls_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNewUpstreamTLSConfig(t *testing.T) {
+	const serverName = "example.com"
+	cfg := newUpstreamTLSConfig(serverName)
+
+	if cfg.ServerName != serverName {
+		t.Fatalf("ServerName = %q, want %q", cfg.ServerName, serverName)
+	}
+	if cfg.InsecureSkipVerify {
+		t.Fatal("upstream TLS certificate verification must be enabled")
+	}
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %d, want TLS 1.2 (%d)", cfg.MinVersion, tls.VersionTLS12)
+	}
+}


### PR DESCRIPTION
## Summary

Enable upstream TLS certificate verification for all WebSocket connections.

The proxy previously configured `tls.Config` with `InsecureSkipVerify: true` in three connection paths:

* direct WebSocket connections;
* Cloudflare proxy domain connections;
* Cloudflare Worker connections.

This disabled certificate chain and hostname verification for upstream TLS connections.

## Changes

* added a shared `newUpstreamTLSConfig` helper;
* removed all uses of `InsecureSkipVerify`;
* preserved the correct TLS `ServerName` for SNI and hostname verification;
* set the minimum supported TLS version to TLS 1.2;
* added a unit test covering:

  * certificate verification being enabled;
  * correct `ServerName`;
  * minimum TLS version.

## Security impact

Upstream WebSocket connections now reject expired, untrusted, or hostname-mismatched certificates instead of accepting them silently.

This reduces the risk of man-in-the-middle attacks against upstream TLS connections.

## Compatibility

The packages already depend on `ca-certificates` for both Entware and OpenWrt builds, so trusted root certificates should be available at runtime.

Connections to endpoints using invalid or self-signed certificates will now fail unless their issuing CA is installed in the system trust store.

## Validation

* source code formatted with `gofmt`;
* added unit coverage for the TLS configuration;
* verified that the diff only changes `src/transport.go` and adds `src/transport_tls_test.go`.

A full local `go test ./...` run was not performed in the publishing environment because external dependency downloads were unavailable.
